### PR TITLE
Ignore PMD violations on lines with only whitespace

### DIFF
--- a/diff-pmd/src/main/java/io/github/yangziwen/pmd/Main.java
+++ b/diff-pmd/src/main/java/io/github/yangziwen/pmd/Main.java
@@ -69,6 +69,7 @@ import net.sourceforge.pmd.util.datasource.DataSource;
 import net.sourceforge.pmd.util.datasource.ReaderDataSource;
 import net.sourceforge.pmd.util.log.ConsoleLogHandler;
 import net.sourceforge.pmd.util.log.ScopedLogHandlersManager;
+import org.eclipse.jgit.diff.RawTextComparator;
 
 /**
  * This is the main class for interacting with PMD. The primary flow of all Rule
@@ -455,7 +456,10 @@ public class Main {
             oldRev = includeStagedCodes ? "HEAD" : "HEAD~";
         }
         String newRev = "HEAD";
-        DiffCalculator calculator = DiffCalculator.builder().diffAlgorithm(new HistogramDiff()).build();
+        DiffCalculator calculator = DiffCalculator.builder()
+                .comparator(configuration.isIgnoreWhitespace() ? RawTextComparator.WS_IGNORE_ALL : RawTextComparator.DEFAULT)
+                .diffAlgorithm(new HistogramDiff()).build();
+
         try {
             List<DiffEntryWrapper> diffEntryList = calculator.calculateDiff(repoDir, oldRev, newRev, includeStagedCodes)
                     .stream()

--- a/diff-pmd/src/main/java/io/github/yangziwen/pmd/PMDConfiguration.java
+++ b/diff-pmd/src/main/java/io/github/yangziwen/pmd/PMDConfiguration.java
@@ -28,6 +28,10 @@ public class PMDConfiguration extends net.sourceforge.pmd.PMDConfiguration {
     @Setter
     private String excludeRegexp;
 
+    @Getter
+    @Setter
+    private boolean ignoreWhitespace;
+
     @Override
     public Renderer createRenderer(boolean withReportWriter) {
         Renderer renderer = RendererFactory.createRenderer(getReportFormat(), getReportProperties());

--- a/diff-pmd/src/main/java/io/github/yangziwen/pmd/cli/PMDParameters.java
+++ b/diff-pmd/src/main/java/io/github/yangziwen/pmd/cli/PMDParameters.java
@@ -99,6 +99,9 @@ public class PMDParameters {
     @Parameter(names = "-norulesetcompatibility", description = "Disable the ruleset compatibility filter. The filter is active by default and tries automatically 'fix' old ruleset files with old rule names")
     private boolean noRuleSetCompatibility = false;
 
+    @Parameter(names = "-ignorewhitespace", description = "Ignore violations on lines that only have whitespace")
+    private boolean ignoreWhitespace = false;
+
     // this has to be a public static class, so that JCommander can use it!
     public static class PropertyConverter implements IStringConverter<Properties> {
 
@@ -165,6 +168,7 @@ public class PMDParameters {
         configuration.setBaseRev(params.getBaseRev());
         configuration.setIncludeStagedCodes(params.isIncludeStagedCodes());
         configuration.setExcludeRegexp(params.getExcludeRegexp());
+        configuration.setIgnoreWhitespace(params.ignoreWhitespace);
 
         LanguageVersion languageVersion = LanguageRegistry.findLanguageVersionByTerseName(params.getLanguage() + " " + params.getVersion());
         if(languageVersion != null) {


### PR DESCRIPTION
We have a codebase with mixed white-space indentation. We use the checkstyle module from this repo to enforce using spaces only. Sometimes it forces us to update lines close to other changes (which is fine).

Unfortunately we have had a few instances where lines which only had whitespace changes then failed the PMD checks. 

To avoid this I've added an option where PMD checks can ignore lines which only include whitespace changes.