### PR TITLE
fix(路径处理): 修正文件路径分隔符处理逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 *.class
 .DS_Store
 dependency-reduced-pom.xml
+
+.idea/

--- a/diff-jacoco-maven-plugin/src/main/java/io/github/yangziwen/jacoco/filter/DiffFilter.java
+++ b/diff-jacoco-maven-plugin/src/main/java/io/github/yangziwen/jacoco/filter/DiffFilter.java
@@ -21,7 +21,7 @@ import io.github.yangziwen.jacoco.util.LineNumberNodeWrapper;
 
 public class DiffFilter implements IFilter {
 
-    private static final String SOURCE_PATH_PREFIX = "/src/main/java/";
+    private static final String SOURCE_PATH_PREFIX = File.separator + "src" + File.separator + "main" + File.separator + "java" + File.separator;
 
     private Map<String, DiffEntryWrapper> classPathDiffEntryMap = new HashMap<>();
 
@@ -30,14 +30,16 @@ public class DiffFilter implements IFilter {
         String baseDirPath = baseDir.getAbsolutePath();
         List<String> modules = project.getModules();
         for (DiffEntryWrapper entry : entries) {
-            if (!entry.getAbsoluteNewPath().startsWith(baseDirPath)) {
+            String absolutePath = entry.getAbsoluteNewPath();
+            if (!absolutePath.startsWith(baseDirPath)) {
                 continue;
             }
-            String name = StringUtils.replaceOnce(entry.getAbsoluteNewPath(), baseDirPath, "");
+            String name = StringUtils.replaceOnce(absolutePath, baseDirPath, "");
             if (CollectionUtil.isNotEmpty(modules)) {
                 for (String module : modules) {
-                    if (name.startsWith("/" + module)) {
-                        name = StringUtils.replaceOnce(name, "/" + module, "");
+                    String modulePrefix = File.separator + module;
+                    if (name.startsWith(modulePrefix)) {
+                        name = StringUtils.replaceOnce(name, modulePrefix , "");
                         break;
                     }
                 }
@@ -45,7 +47,8 @@ public class DiffFilter implements IFilter {
             if (!name.startsWith(SOURCE_PATH_PREFIX)) {
                 continue;
             }
-            name = StringUtils.replaceOnce(name, SOURCE_PATH_PREFIX, "");
+            name = StringUtils.replaceOnce(name, SOURCE_PATH_PREFIX, "").replace(File.separator, "/");
+            //name 与 FilterUtil.getClassPath 一致才能获取到
             classPathDiffEntryMap.put(name, entry);
         }
     }

--- a/diff-jacoco-maven-plugin/src/main/java/io/github/yangziwen/jacoco/util/FilterUtil.java
+++ b/diff-jacoco-maven-plugin/src/main/java/io/github/yangziwen/jacoco/util/FilterUtil.java
@@ -42,8 +42,16 @@ public class FilterUtil {
         modifiersField.setInt(filtersField, modifiers);
     }
 
+    /**
+     * 返回类文件的路径和名称
+     * @return 例如：com/example/Example.java
+     */
     public static String getClassPath(IFilterContext context) {
-        int lastSlashIndex = context.getClassName().lastIndexOf(File.separator);
+        /*
+         ASM 的 ClassReader 获取的 className 是内部名称格式（Internal Name），使用斜杠 / 作为包分隔符
+         返回的斜杠格式是 JVM 规范定义的内部名称格式，不是文件系统路径。
+         */
+        int lastSlashIndex = context.getClassName().lastIndexOf("/");
         String path = context.getSourceFileName();
         if (lastSlashIndex >= 0) {
             path = context.getClassName().substring(0, lastSlashIndex + 1) + context.getSourceFileName();


### PR DESCRIPTION
- 将硬编码的路径分隔符替换为系统相关的File.separator
- 修正FilterUtil中类路径处理逻辑，使用JVM规范的斜杠分隔符
- 添加includeStagedCodes参数控制是否包含暂存区代码
- 增加日志输出以帮助调试
- 更新.gitignore文件忽略.idea目录