### PR TITLE
Added whole file checks

### DIFF
--- a/diff-checkstyle/src/main/java/io/github/yangziwen/checkstyle/Main.java
+++ b/diff-checkstyle/src/main/java/io/github/yangziwen/checkstyle/Main.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.github.yangziwen.checkstyle.filter.WholeDiffFilter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -472,10 +473,13 @@ public final class Main {
             rootModule.configure(config);
             rootModule.addListener(listener);
 
+            List<com.puppycrawl.tools.checkstyle.api.Filter> filters = new ArrayList<>();
             if (CollectionUtils.isNotEmpty(DIFF_ENTRY_LIST) && rootModule instanceof Checker) {
-                Checker checker = (Checker) rootModule;
-                checker.addFilter(new DiffLineFilter(DIFF_ENTRY_LIST));
+                filters.add(new DiffLineFilter(DIFF_ENTRY_LIST));
+                filters.add(new WholeDiffFilter(options.wholeFileChecks));
             }
+            Checker checker = (Checker) rootModule;
+            checker.addFilter(evt -> filters.stream().anyMatch(f -> f.accept(evt)));
 
             // run RootModule
             errorCounter = rootModule.process(filesToProcess);
@@ -865,6 +869,11 @@ public final class Main {
         @Option(names = {"-is", "--include-staged-codes"},
                 description = "Whether to include indexed codes when calculating differencies of codes")
         private boolean gitIncludeStagedCodes;
+
+        @Option(names = {"-wfc", "--whole-file-checks"},
+                arity = "1..*",
+                description = "Checkstyle rules to apply to whole files")
+        private List<String> wholeFileChecks = new ArrayList<>();
 
         /**
          * Gets the list of exclusions provided through the command line arguments.

--- a/diff-checkstyle/src/main/java/io/github/yangziwen/checkstyle/filter/WholeDiffFilter.java
+++ b/diff-checkstyle/src/main/java/io/github/yangziwen/checkstyle/filter/WholeDiffFilter.java
@@ -1,0 +1,22 @@
+package io.github.yangziwen.checkstyle.filter;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.Filter;
+import com.puppycrawl.tools.checkstyle.api.Violation;
+
+import java.util.List;
+
+public class WholeDiffFilter implements Filter {
+
+    private final List<String> checkNames;
+
+    public WholeDiffFilter(List<String> checks) {
+        this.checkNames = checks;
+    }
+
+    @Override
+    public boolean accept(AuditEvent event) {
+        Violation v = event.getViolation();
+        return checkNames.stream().anyMatch(checkName -> v.getSourceName().contains(checkName));
+    }
+}


### PR DESCRIPTION
Added an option for whole file checks for specific rules. 

The main use-case is for unused imports. Existing codebases may be littered with unused imports which can easily be removed when a file is being changed. Or when an implementation changes there may be imports that _become_ unused.

The code changes here add a new option where listed rules can be checked. The rules provided to the command line argument must match a module/rule/check in the Checkstyle configuration for a violation to be flagged.

Usage example: ` -c checkstyle.xml --git-dir . --base-rev master -wfc UnusedImport ModifierOrder -- src/* `

Will match any violations of UnusedImport and ModifierOrder in any changed files.